### PR TITLE
feat: Add a 15-second timer for each question

### DIFF
--- a/Quiz.py
+++ b/Quiz.py
@@ -1,3 +1,19 @@
+import time
+import threading
+import sys # Using sys to try and flush input, might not work reliably across platforms
+
+# Flag to signal timeout
+timeout_flag = [False] # Using a list as a mutable object for the thread to modify
+
+def time_up():
+    """Function called by the timer when time expires."""
+    timeout_flag[0] = True
+    print("\n⏳ Time's up! Press Enter to continue.")
+    # Attempt to interrupt input (might not work reliably)
+    # This is platform-dependent and generally difficult with standard input()
+    # On Unix-like systems, one might use signals, but that's complex.
+    # On Windows, libraries like msvcrt could be used.
+    # For simplicity here, we rely on the user pressing Enter.
 
 def run_quiz(questions):
     score = 0
@@ -5,12 +21,47 @@ def run_quiz(questions):
         print("\n" + q["question"])
         for option in q["options"]:
             print(option)
-        answer = input("Your answer (A/B/C/D): ").strip().upper()
-        if answer == q["answer"]:
-            print("✅ Correct!")
-            score += 1
-        else:
-            print(f"❌ Wrong! Correct answer: {q['answer']}")
+
+        timeout_flag[0] = False # Reset flag for the new question
+        timer = threading.Timer(15.0, time_up) # 15-second timer
+
+        start_time = time.time()
+        timer.start() # Start the timer
+
+        try:
+            # Prompt for input
+            answer = input("Your answer (A/B/C/D): ").strip().upper()
+
+            # If we get here, the user entered something before the timer ideally finished
+            # or they pressed Enter after the timeout message.
+            timer.cancel() # Cancel the timer as the user responded or acknowledged timeout
+
+            end_time = time.time()
+            time_taken = end_time - start_time
+
+            if timeout_flag[0]:
+                # Time ran out before valid input was processed, or user pressed Enter after timeout
+                print("❌ Marked as incorrect due to timeout.")
+                # No score added for timeout
+            elif time_taken > 15:
+                 print(f"⏱️ Time taken: {time_taken:.2f} seconds (Over limit!)")
+                 print(f"❌ Wrong! Correct answer: {q['answer']}")
+                 # Optionally penalize if answering *after* timer function printed but before pressing enter took too long
+            else:
+                # User answered within time
+                print(f"⏱️ Time taken: {time_taken:.2f} seconds")
+                if answer == q["answer"]:
+                    print("✅ Correct!")
+                    score += 1
+                else:
+                    print(f"❌ Wrong! Correct answer: {q['answer']}")
+
+        except EOFError:
+             # Handles cases where input stream might be closed unexpectedly
+             timer.cancel()
+             print("\nInput error. Moving to next question.")
+
+
     print(f"\nYour final score: {score} out of {len(questions)}")
 
 questions = [


### PR DESCRIPTION
This commit introduces a timer feature to the quiz application.

- Each question now has a 15-second time limit.
- The time taken to answer each question is displayed if answered within the limit.
- If you exceed the time limit, the answer is marked as incorrect, and a "Time's up!" message is shown.
- Uses the `threading` module to run the timer concurrently with your input.
- Includes necessary imports (`time`, `threading`) and updates to the `run_quiz` function logic and user feedback messages.